### PR TITLE
Avoid "Press ENTER" prompt

### DIFF
--- a/autoload/startuptime.vim
+++ b/autoload/startuptime.vim
@@ -233,7 +233,7 @@ function! startuptime#profile(...) abort
   enew
   silent %put=lines
   call cursor(1, 1)
-  delete _
+  silent delete _
   set buftype=nofile syntax=help foldmethod=marker foldmarker=>,< nomodified
   normal! zM
 endfunction


### PR DESCRIPTION
This happens because a non-silent `:delete` will issue a "1 line less" message, when `set report=0`.